### PR TITLE
Add the avoid_edge & center options

### DIFF
--- a/README
+++ b/README
@@ -53,6 +53,13 @@ DATA REPRESENTATION
 
         In the algorithm description, this constant is named *k*.
 
+    *   `< avoid_edge'> - The distance from the edge of the plot.
+
+        Default is 0
+
+        If greater than zero, this will not plot points within that distance
+        from the edge.
+
   INTERNAL SUBROUTINES
     These subroutines are used for the algorithm. If you want to port this
     module to PDL or any other vector library, you will likely have to

--- a/README
+++ b/README
@@ -60,6 +60,13 @@ DATA REPRESENTATION
         If greater than zero, this will not plot points within that distance
         from the edge.
 
+    *   `< center'> - Start adding points at the center of the cube.
+
+        Default is 0
+
+        If this is set to the default, the initial point will be added at a
+        random position in the cube.
+
   INTERNAL SUBROUTINES
     These subroutines are used for the algorithm. If you want to port this
     module to PDL or any other vector library, you will likely have to

--- a/README
+++ b/README
@@ -60,12 +60,12 @@ DATA REPRESENTATION
         If greater than zero, this will not plot points within that distance
         from the edge.
 
-    *   `< center'> - Start adding points at the center of the cube.
+    *   `< center'> - Start adding points at the center of the plot.
 
         Default is 0
 
         If this is set to the default, the initial point will be added at a
-        random position in the cube.
+        random position in the plot.
 
   INTERNAL SUBROUTINES
     These subroutines are used for the algorithm. If you want to port this

--- a/lib/Random/PoissonDisc.pm
+++ b/lib/Random/PoissonDisc.pm
@@ -79,6 +79,14 @@ the longer the algorithm will run for generating a number of points.
 
 In the algorithm description, this constant is named I<k>.
 
+=item *
+
+C<< avoid_edge >> - The distance from the edge of the plot.
+
+Default is C<0>
+
+If greater than zero, this will not plot points within that distance from the edge.
+
 =back
 
 =cut
@@ -86,6 +94,7 @@ In the algorithm description, this constant is named I<k>.
 sub points {
     my ($class,%options) = @_;
     
+    $options{avoid_edge} ||= 0;
     $options{candidates} ||= 30;
     $options{dimensions} ||= [100,100]; # do we only create integral points?
     $options{r} ||= 10;
@@ -122,8 +131,8 @@ sub points {
             # Check whether our point lies within the dimensions
             for (0..$#$p) {
                  next CANDIDATE
-                    if   $p->[$_] >= $options{ dimensions }->[ $_ ]
-                      or $p->[$_] < 0
+                    if   $p->[$_] >= $options{ dimensions }->[ $_ ] - $options{ avoid_edge }
+                      or $p->[$_] < $options{ avoid_edge }
             };
             
             # check discs by using the grid

--- a/lib/Random/PoissonDisc.pm
+++ b/lib/Random/PoissonDisc.pm
@@ -89,12 +89,12 @@ If greater than zero, this will not plot points within that distance from the ed
 
 =item *
 
-C<< center >> - Start adding points at the center of the cube.
+C<< center >> - Start adding points at the center of the plot.
 
 Default is C<0>
 
 If this is set to the default, the initial point will be added at a
-random position in the cube.
+random position in the plot.
 
 =back
 

--- a/lib/Random/PoissonDisc.pm
+++ b/lib/Random/PoissonDisc.pm
@@ -87,6 +87,15 @@ Default is C<0>
 
 If greater than zero, this will not plot points within that distance from the edge.
 
+=item *
+
+C<< center >> - Start adding points at the center of the cube.
+
+Default is C<0>
+
+If this is set to the default, the initial point will be added at a
+random position in the cube.
+
 =back
 
 =cut
@@ -94,6 +103,7 @@ If greater than zero, this will not plot points within that distance from the ed
 sub points {
     my ($class,%options) = @_;
     
+    $options{center}     ||= 0;
     $options{avoid_edge} ||= 0;
     $options{candidates} ||= 30;
     $options{dimensions} ||= [100,100]; # do we only create integral points?
@@ -106,8 +116,10 @@ sub points {
     my @result;
     my @work;
         
-    # Create a first random point somewhere in our cube:
-    my $p = [map { rnd(0,$_) } @{ $options{ dimensions }}];
+    # Create a first point in our cube - either at random or in the center:
+    my $p = $options{ center }
+        ? [map { $_ / 2 } @{ $options{ dimensions }}]
+        : [map { rnd(0,$_) } @{ $options{ dimensions }}];
     push @result, $p;
     push @work, $p;
     my $c = grid_coords($grid_size, $p);


### PR DESCRIPTION
These commits add `avoid_edge` and `center` options.  The first prevents points from plotted on or next to the graph edges. The second allows the plot to be drawn from the center, outward.